### PR TITLE
ci(renovate): disable fedora docker dep updates on build yaml

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,5 +44,13 @@
       commitMessageTopic: '⇡ github actions {{depName}}',
       matchUpdateTypes: ['minor', 'patch']
     },
+    {
+      "packageNames": ["fedora"],
+      "enabled": false,
+      "groupName": "docker-fedora",
+      "matchUpdateTypes": ["container"],
+      "matchDatasources": ["docker"],
+      "enabledStatus": "disabled"
+    }
   ]
 }


### PR DESCRIPTION
pinning fedora docker build version as to update when config updates